### PR TITLE
turning this ESLint check off

### DIFF
--- a/backend/functions/.eslintrc.js
+++ b/backend/functions/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     "no-restricted-globals": ["error", "name", "length"],
     "prefer-arrow-callback": "error",
     "quotes": ["error", "double", {"allowTemplateLiterals": true}],
+    "new-cap": ["error", {"capIsNewExceptions": ["Router"]}],
   },
   overrides: [
     {


### PR DESCRIPTION
I just want to test this PR system. I was getting an error in the test.js file because of ESLint so I added an exception for it:
The capital R in "const router = express.Router();"
